### PR TITLE
Resolved the conflict between asynchronous Reducer and Pipeline parallelism

### DIFF
--- a/nnscaler/cli/trainer.py
+++ b/nnscaler/cli/trainer.py
@@ -787,7 +787,9 @@ class Trainer:
                 desc=epoch_desc,
                 disable=not self.train_args.enable_progress_bar,
             )
-
+        from nnscaler.utils import accum_Manager
+        accum_manager=accum_Manager()
+        accum_manager.set_nsteps(self.train_args.update_freq)
         step_stat: Optional[_StepStat] = None
         for i, batches in data_iter:
             idx = i + resume_from_idx
@@ -798,6 +800,7 @@ class Trainer:
             num_batches = len(batches)
             batches, is_dummy_batch = self._fix_batches(batches)
 
+            accum_manager.reset()
             self.model.train()
 
             self.hook.before_zero_grad(self)

--- a/nnscaler/runtime/executor.py
+++ b/nnscaler/runtime/executor.py
@@ -188,6 +188,10 @@ class Executor:
                     dedup_output_tensors,
                     dedup_output_tensor_grads
                 )
+        
+        from nnscaler.utils import accum_Manager
+        accum_manager=accum_Manager()
+        accum_manager.step()
 
         torch.autograd.backward(
             dedup_output_tensors,

--- a/nnscaler/runtime/module.py
+++ b/nnscaler/runtime/module.py
@@ -975,14 +975,11 @@ class ParallelModule(CubeModule):
         if self.use_scheduler:
             if len(samples) != self.nmicros_per_scheduler_step:
                 raise ValueError(f"Expected {self.nmicros_per_scheduler_step} samples, but got {sample_count}")
-            # only one step, so begin/end are both True
-            with accum_mode(begin=True, end=True):
-                return self._train_step(dataloader)
+            return self._train_step(dataloader)
         else:
             outputs = []
             for idx in range(sample_count):
-                with accum_mode(begin=(idx==0), end=(idx==sample_count-1)):
-                    output = self._train_step(dataloader)
+                output = self._train_step(dataloader)
                 outputs.append(output)
             return outputs
 

--- a/nnscaler/utils.py
+++ b/nnscaler/utils.py
@@ -419,3 +419,26 @@ class accum_mode:
             RuntimeFlag.skip_reducer = (not (step == nsteps - 1))
             yield step
         RuntimeFlag.skip_zero_grad, RuntimeFlag.skip_reducer = old
+
+class accum_Manager:
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super(accum_Manager, cls).__new__(cls, *args, **kwargs)
+            cls._instance.nsteps=1
+            cls._instance.now_step=0
+            cls._instance.old=(RuntimeFlag.skip_zero_grad, RuntimeFlag.skip_reducer)
+        return cls._instance
+    
+    def set_nsteps(self,nsteps):
+        self.nsteps=nsteps
+    
+    def step(self):
+        RuntimeFlag.skip_zero_grad = (not (self.now_step == 0))
+        RuntimeFlag.skip_reducer = (not (self.now_step == self.nsteps - 1))
+        self.now_step+=1
+    
+    def reset(self):
+        self.now_step=0
+        RuntimeFlag.skip_zero_grad, RuntimeFlag.skip_reducer = self.old


### PR DESCRIPTION
The current pipeline parallelism generates multiple backward codes within gencode.py. If asynchronous gradient communication is used, the post_grad_hook in reducer.py will perform gradient synchronization during each backward pass, triggering errors. I have created a singleton class accum_Manager in nnscaler/utils.py to manage gradient accumulation and gradient synchronization communication. Asynchronous gradient communication only occurs when the number of backward passes reaches the specified gradient accumulation steps.

In nnscaler/cli/trainer.py at line 791, this instance is created, and the set_nsteps function is called to specify the gradient accumulation steps. Additionally, accum_manager.reset() is added at line 803 to reset the accumulation step count for each iteration. In runtime/executor.py at line 194, the step() function is called to increment the backward pass count.